### PR TITLE
fix: use containerized redis

### DIFF
--- a/backend/config.ini.template
+++ b/backend/config.ini.template
@@ -11,7 +11,7 @@ charset = utf8mb4
 debug = 1
 
 [Redis]
-host = host.docker.internal
+host = redis
 port = 6379
 db = 0
 stream_key = crawler:log

--- a/backend/routes/status.py
+++ b/backend/routes/status.py
@@ -46,19 +46,22 @@ def get_fetch_log():
         last_id = request.headers.get('Last-Event-ID', '0')
 
         # Phase 1: catch up missed messages
-        if last_id == '0':
-            history = r.xrange(STREAM_KEY, min='-', max='+')
-        else:
-            history = r.xrange(STREAM_KEY, min=f'({last_id}', max='+')
+        try:
+            if last_id == '0':
+                history = r.xrange(STREAM_KEY, min='-', max='+')
+            else:
+                history = r.xrange(STREAM_KEY, min=f'({last_id}', max='+')
 
-        for msg_id, fields in history:
-            yield format_sse_event('log', msg_id, fields.get('msg', ''))
-            last_id = msg_id
+            for msg_id, fields in history:
+                yield format_sse_event('log', msg_id, fields.get('msg', ''))
+                last_id = msg_id
 
-        # Push current status
-        status_data = r.get(STATUS_KEY)
-        if status_data:
-            yield format_sse_event('meta', last_id, status_data)
+            # Push current status
+            status_data = r.get(STATUS_KEY)
+            if status_data:
+                yield format_sse_event('meta', last_id, status_data)
+        except redis.ConnectionError:
+            yield format_sse_event('log', '0', '[系统] Redis 连接失败，重试中...')
 
         # Phase 2: block on new messages
         while True:

--- a/crawler/update_courses.sh
+++ b/crawler/update_courses.sh
@@ -16,7 +16,7 @@ STATIC_PAGE_DIR="/var/www/shared_pages"
 # Function to push log line to Redis Stream
 report_log() {
     echo "$1"
-    redis-cli XADD crawler:log MAXLEN '~' 5000 '*' msg "$1" > /dev/null 2>&1 || true
+    redis-cli -p 6380 XADD crawler:log MAXLEN '~' 5000 '*' msg "$1" > /dev/null 2>&1 || true
 }
 
 # Function to write status atomically via Redis SET
@@ -27,7 +27,7 @@ write_status() {
     local end_time="${4:-}"
     printf '{"status":"%s","message":"%s","startTime":"%s","endTime":"%s"}' \
         "$status" "$message" "$start_time" "$end_time" \
-        | redis-cli -x SET crawler:status > /dev/null 2>&1 || true
+        | redis-cli -p 6380 -x SET crawler:status > /dev/null 2>&1 || true
 }
 
 # Function to restore original nginx configs on exit
@@ -45,7 +45,7 @@ restore_nginx() {
 trap 'restore_nginx' EXIT
 
 # Start fresh — clear old Redis stream data
-redis-cli DEL crawler:log crawler:status > /dev/null 2>&1 || true
+redis-cli -p 6380 DEL crawler:log crawler:status > /dev/null 2>&1 || true
 START_TIME=$(date '+%Y-%m-%dT%H:%M:%S')
 report_log "[$(date '+%Y-%m-%d %H:%M:%S')] 开始数据更新任务"
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,18 @@
 services:
+  redis:
+    image: redis:8.4-alpine
+    container_name: xk-redis
+    ports:
+      - "6380:6379"
+    restart: always
+
   backend:
     build: ./backend
     container_name: xk-backend
     ports:
       - "1239:1239"
+    depends_on:
+      - redis
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:1239/api/health"]
       interval: 30s


### PR DESCRIPTION
redis 有安全限制，容器化才可方便使用。为了和宿主机上的现有 redis 区分开，用 6380 端口