### PR TITLE
Feat/slow query optimize

### DIFF
--- a/backend/db/course.py
+++ b/backend/db/course.py
@@ -62,9 +62,9 @@ class CourseQueries(ReadConnection):
             'courseNature', JSON_ARRAYAGG(DISTINCT n.courseLabelName),
             'courses', JSON_ARRAYAGG(JSON_OBJECT(
                 'code', c.code,
-                'teachers', teachers.teachers,
+                'teachers', teacher_info.teachers,
                 'campus', ca.campusI18n,
-                'locations', locations.locations,
+                'locations', teacher_info.locations,
                 'teachingLanguage', l.teachingLanguageI18n,
                 'isExclusive', IF(mac_exclusive.majorId IS NOT NULL, TRUE, FALSE)
             ))
@@ -79,13 +79,10 @@ class CourseQueries(ReadConnection):
                    JSON_ARRAYAGG(JSON_OBJECT(
                        'teacherCode', t.teacherCode,
                        'teacherName', t.teacherName
-                   )) AS teachers
+                   )) AS teachers,
+                   GROUP_CONCAT(DISTINCT t.arrangeInfoText SEPARATOR '') AS locations
             FROM teacher AS t GROUP BY t.teachingClassid
-        ) AS teachers ON c.id = teachers.teachingClassid
-        JOIN (
-            SELECT t.teachingClassid, GROUP_CONCAT(DISTINCT t.arrangeInfoText SEPARATOR '') AS locations
-            FROM teacher AS t GROUP BY t.teachingClassid
-        ) AS locations ON c.id = locations.teachingClassid
+        ) AS teacher_info ON c.id = teacher_info.teachingClassid
         JOIN (
             SELECT DISTINCT c.courseCode as myCode, m.grade, m.id as targetMajorId
             FROM major AS m
@@ -169,9 +166,9 @@ class CourseQueries(ReadConnection):
         query = f"""
         SELECT c.courseCode, JSON_OBJECT(
             'code', c.code,
-            'teachers', teachers.teachers,
+            'teachers', teacher_info.teachers,
             'campus', ca.campusI18n,
-            'locations', locations.locations,
+            'locations', teacher_info.locations,
             'teachingLanguage', l.teachingLanguageI18n
         )
         FROM coursedetail as c
@@ -182,13 +179,10 @@ class CourseQueries(ReadConnection):
                    JSON_ARRAYAGG(JSON_OBJECT(
                        'teacherCode', t.teacherCode,
                        'teacherName', t.teacherName
-                   )) AS teachers
+                   )) AS teachers,
+                   GROUP_CONCAT(DISTINCT t.arrangeInfoText SEPARATOR '') AS locations
             FROM teacher AS t GROUP BY t.teachingClassid
-        ) AS teachers ON c.id = teachers.teachingClassid
-        JOIN (
-            SELECT t.teachingClassid, GROUP_CONCAT(DISTINCT t.arrangeInfoText SEPARATOR '') AS locations
-            FROM teacher AS t GROUP BY t.teachingClassid
-        ) AS locations ON c.id = locations.teachingClassid
+        ) AS teacher_info ON c.id = teacher_info.teachingClassid
         WHERE c.courseCode IN ({placeholders})
         """
         self.cursor.execute(query, tuple(codes))
@@ -297,10 +291,10 @@ class CourseQueries(ReadConnection):
             query = f"""
             SELECT c.courseCode, JSON_OBJECT(
                 'code', c.code,
-                'teachers', teachers.teachers,
+                'teachers', teacher_info.teachers,
                 'campusI18n', ca.campusI18n,
                 'teachingLanguageI18n', l.teachingLanguageI18n,
-                'arrangementInfo', locations.locations,
+                'arrangementInfo', teacher_info.locations,
                 'isExclusive', IF(mac_exclusive.majorId IS NOT NULL, TRUE, FALSE)
             )
             FROM coursedetail as c
@@ -310,12 +304,10 @@ class CourseQueries(ReadConnection):
                 SELECT t.teachingClassid,
                        JSON_ARRAYAGG(JSON_OBJECT(
                            'teacherCode', t.teacherCode, 'teacherName', t.teacherName
-                       )) as teachers
+                       )) as teachers,
+                       GROUP_CONCAT(DISTINCT t.arrangeInfoText SEPARATOR '') as locations
                 FROM teacher as t GROUP BY t.teachingClassid
-            ) as teachers ON c.id = teachers.teachingClassid
-            JOIN (
-                SELECT t.teachingClassid, t.arrangeInfoText as locations FROM teacher as t
-            ) as locations ON c.id = locations.teachingClassid
+            ) as teacher_info ON c.id = teacher_info.teachingClassid
             LEFT JOIN (
                 SELECT DISTINCT c2.id as courseId, m2.id as targetMajorId
                 FROM major AS m2
@@ -340,10 +332,10 @@ class CourseQueries(ReadConnection):
             query = f"""
             SELECT c.courseCode, JSON_OBJECT(
                 'code', c.code,
-                'teachers', teachers.teachers,
+                'teachers', teacher_info.teachers,
                 'campusI18n', ca.campusI18n,
                 'teachingLanguageI18n', l.teachingLanguageI18n,
-                'arrangementInfo', locations.locations
+                'arrangementInfo', teacher_info.locations
             )
             FROM coursedetail as c
             JOIN campus as ca ON c.campus = ca.campus
@@ -352,12 +344,10 @@ class CourseQueries(ReadConnection):
                 SELECT t.teachingClassid,
                        JSON_ARRAYAGG(JSON_OBJECT(
                            'teacherCode', t.teacherCode, 'teacherName', t.teacherName
-                       )) as teachers
+                       )) as teachers,
+                       GROUP_CONCAT(DISTINCT t.arrangeInfoText SEPARATOR '') as locations
                 FROM teacher as t GROUP BY t.teachingClassid
-            ) as teachers ON c.id = teachers.teachingClassid
-            JOIN (
-                SELECT t.teachingClassid, t.arrangeInfoText as locations FROM teacher as t
-            ) as locations ON c.id = locations.teachingClassid
+            ) as teacher_info ON c.id = teacher_info.teachingClassid
             WHERE c.courseCode IN ({placeholders})
             """
             self.cursor.execute(query, tuple(otherCourseCodes))

--- a/backend/db/course.py
+++ b/backend/db/course.py
@@ -207,6 +207,16 @@ class CourseQueries(ReadConnection):
         params = []
         condition = ""
 
+        # ── 内层按需 JOIN（仅筛选所需的表）──
+        inner_joins = ""
+        if searchBody.get('teacherCode') or searchBody.get('teacherName'):
+            inner_joins += " JOIN teacher AS t ON t.teachingClassid = c.id"
+        if searchBody.get('campus'):
+            inner_joins += " JOIN campus AS ca ON ca.campus = c.campus"
+        if searchBody.get('faculty'):
+            inner_joins += " JOIN faculty AS f ON f.faculty = c.faculty"
+
+        # ── 筛选条件 ──
         if searchBody.get('courseName'):
             condition += " AND c.courseName LIKE %s"
             params.append("%" + searchBody["courseName"] + "%")
@@ -235,14 +245,20 @@ class CourseQueries(ReadConnection):
             'courseNature', JSON_ARRAYAGG(DISTINCT n.courseLabelName),
             'campus', JSON_ARRAYAGG(DISTINCT ca.campusI18n ORDER BY ca.campusI18n)
         )
-        FROM coursedetail as c
-        JOIN faculty AS f ON f.faculty = c.faculty
-        JOIN campus as ca ON ca.campus = c.campus
-        JOIN coursenature as n ON c.courseLabelId = n.courseLabelId
-        JOIN teacher as t ON t.teachingClassid = c.id
-        WHERE 1=1 {condition}
+        FROM (
+            SELECT DISTINCT c.courseCode
+            FROM coursedetail c
+            {inner_joins}
+            WHERE 1=1 {condition}
+            ORDER BY c.courseCode
+            LIMIT %s
+        ) AS codes
+        JOIN coursedetail c ON c.courseCode = codes.courseCode
+        JOIN faculty f ON f.faculty = c.faculty
+        JOIN campus ca ON ca.campus = c.campus
+        JOIN coursenature n ON n.courseLabelId = n.courseLabelId
         GROUP BY c.courseCode, c.courseName, f.facultyI18n, c.credit
-        LIMIT %s
+        ORDER BY c.courseCode
         """
         params.append(sizeLimit)
         self.cursor.execute(sql, tuple(params))

--- a/backend/routes/course.py
+++ b/backend/routes/course.py
@@ -4,7 +4,7 @@ from datetime import datetime
 from flask import Blueprint, request
 
 from bckndSql import bckndSql
-from utils.bckndTools import arrangementTextToObj, splitEndline, optCourseQueryListGenerator
+from utils.bckndTools import optCourseQueryListGenerator, processArrangements
 from utils.response import ok, err
 from utils.redis_cache import cache_get, cache_set, cache_key
 
@@ -78,40 +78,8 @@ def query_courses(calendar_id):
         with bckndSql(calendar_id=calendar_id) as sql:
             result = sql.findCourseByMajor(grade, major)
 
-        # 处理 result 中的 locations 字段
-        # 由于 locations 字段是一个字符串，需要转换为数组
-        # 形如：关佶红(05222) 星期一3-4节 [1-17] 南129\n关佶红(05222) 星期三3-4节 [1-17单] 北301\n
-
         for res in result:
-            for course in res['courses']:
-                course['arrangementInfo'] = []
-                for location in splitEndline(course['locations']):
-                    course['arrangementInfo'].append(arrangementTextToObj(location))
-                # 按照星期（occupyDay）和节次（occupyTime第一节）排序
-                course['arrangementInfo'].sort(key=lambda x: (x['occupyDay'], x['occupyTime'][0] if x['occupyTime'] else 0))
-                del course['locations']
-
-        # 对于 code 相同的课程，合并 arrangementInfo
-        for res in result:
-            res['courses'] = sorted(res['courses'], key=lambda x: x['code'])  # 先排序
-
-            # 合并相同课号的课程
-            merged_courses = []
-            current_course = None
-            for course in res['courses']:
-                if not current_course or current_course['code'] != course['code']:
-                    merged_courses.append(course)
-                    current_course = course
-                else:
-                    # 如果arrangementInfo不同，则合并（去重）
-                    if current_course['arrangementInfo'] != course['arrangementInfo']:
-                        # 使用字典来去重 arrangementInfo（基于 arrangementText）
-                        existing_texts = {item['arrangementText'] for item in current_course['arrangementInfo']}
-                        for item in course['arrangementInfo']:
-                            if item['arrangementText'] not in existing_texts:
-                                current_course['arrangementInfo'].append(item)
-                                existing_texts.add(item['arrangementText'])
-            res['courses'] = merged_courses
+            processArrangements(res['courses'])
 
         cache_set(ck, result, 'hot')
         return ok(result)
@@ -167,36 +135,11 @@ def batch_course_detail(calendar_id):
     with bckndSql(calendar_id=calendar_id) as sql:
         result = sql.findCourseDetailByCode(codes)
 
-    def process(course_list):
-        for course in course_list:
-            course['arrangementInfo'] = []
-            for location in splitEndline(course['locations']):
-                course['arrangementInfo'].append(arrangementTextToObj(location))
-            course['arrangementInfo'].sort(key=lambda x: (x['occupyDay'], x['occupyTime'][0] if x['occupyTime'] else 0))
-            del course['locations']
+    for course_list in result.values():
+        processArrangements(course_list)
 
-        course_list = sorted(course_list, key=lambda x: x['code'])
-        merged = []
-        current = None
-        for course in course_list:
-            if not current or current['code'] != course['code']:
-                merged.append(course)
-                current = course
-            else:
-                if current['arrangementInfo'] != course['arrangementInfo']:
-                    existing_texts = {item['arrangementText'] for item in current['arrangementInfo']}
-                    for item in course['arrangementInfo']:
-                        if item['arrangementText'] not in existing_texts:
-                            current['arrangementInfo'].append(item)
-                            existing_texts.add(item['arrangementText'])
-        return merged
-
-    processed = {}
-    for course_code, course_list in result.items():
-        processed[course_code] = process(course_list)
-
-    cache_set(ck, processed, 'normal')
-    return ok(processed)
+    cache_set(ck, result, 'normal')
+    return ok(result)
 
 
 # ================================================================
@@ -261,49 +204,13 @@ def batch_course_info(calendar_id):
         return ok(cached)
 
     with bckndSql(calendar_id=calendar_id) as sql:
-        result_dict = sql.getLatestCourseInfo(major_course_codes, other_course_codes, major_info)
+        result = sql.getLatestCourseInfo(major_course_codes, other_course_codes, major_info)
 
-        # Process arrangement info for each course code
-        for course_code, course_details in result_dict.items():
-            for detail in course_details:
-                if 'arrangementInfo' in detail and isinstance(detail['arrangementInfo'], str):
-                    # Parse arrangement text - split into list and convert each element
-                    arrangement_text = detail['arrangementInfo']
-                    detail['arrangementInfo'] = []
-                    for location in splitEndline(arrangement_text):
-                        detail['arrangementInfo'].append(arrangementTextToObj(location))
+        for course_details in result.values():
+            processArrangements(course_details, source_key='arrangementInfo')
 
-                    # Sort by day and time
-                    detail['arrangementInfo'].sort(key=lambda x: (x['occupyDay'], x['occupyTime'][0] if x['occupyTime'] else 0))
-
-            # 对于每个课程代码，合并相同 code 的课程（教学班号）
-            if course_details:
-                # 先按 code 排序
-                course_details.sort(key=lambda x: x['code'])
-
-                # 合并相同 code 的课程
-                merged_details = []
-                current_detail = None
-
-                for detail in course_details:
-                    if not current_detail or current_detail['code'] != detail['code']:
-                        merged_details.append(detail)
-                        current_detail = detail
-                    else:
-                        # 合并 arrangementInfo（去重）
-                        if current_detail['arrangementInfo'] != detail['arrangementInfo']:
-                            existing_texts = {item['arrangementText'] for item in current_detail['arrangementInfo']}
-                            for item in detail['arrangementInfo']:
-                                if item['arrangementText'] not in existing_texts:
-                                    current_detail['arrangementInfo'].append(item)
-                                    existing_texts.add(item['arrangementText'])
-
-                            # 重新排序合并后的 arrangementInfo
-                            current_detail['arrangementInfo'].sort(key=lambda x: (x['occupyDay'], x['occupyTime'][0] if x['occupyTime'] else 0))
-                result_dict[course_code] = merged_details
-
-    cache_set(ck, result_dict, 'normal')
-    return ok(result_dict)
+    cache_set(ck, result, 'normal')
+    return ok(result)
 
 
 # ================================================================

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -36,7 +36,9 @@ def seed_data(db_config, test_meta_conn, test_cal_a_conn):
               "(1004, '99900001', '01班', 848, 2, 1, '999000', '测试选修课', 2.0, 1, '000034'),"
               "(2001, '10039501', '01班', 951, 1, 3, '100395', '编译原理', 3.0, 1, '000722'),"
               "(2002, '10039503', '03班', 951, 1, 3, '100395', '编译原理', 3.0, 1, '000722'),"
-              "(2003, '02052701', '01班', 951, 2, 1, '020527', '建筑设计Ⅰ（英）', 4.0, 8, '000163')")
+              "(2003, '02052701', '01班', 951, 2, 1, '020527', '建筑设计Ⅰ（英）', 4.0, 8, '000163'),"
+              # 部分重叠排课：两个教师的安排文本不完全相同，但共享同一行（生产环境真实 case）
+              "(3001, '51111201', '01班', 958, 1, 1, '511112', '生命的省思——如何过好这一生', 2.0, 1, '000034')")
 
     # 教师（含多教师场景）
     c.execute("INSERT INTO teacher VALUES "
@@ -51,7 +53,10 @@ def seed_data(db_config, test_meta_conn, test_cal_a_conn):
               # 建筑设计Ⅰ — 共同排课：3个老师，完全相同
               "(3201, 2003, '14022', '李彦伯', '李彦伯(14022),陈洁(22211),俞泳(99078) 星期三5-8节 [1-16] 学院专教C203\\n'),"
               "(3202, 2003, '22211', '陈洁', '李彦伯(14022),陈洁(22211),俞泳(99078) 星期三5-8节 [1-16] 学院专教C203\\n'),"
-              "(3203, 2003, '99078', '俞泳', '李彦伯(14022),陈洁(22211),俞泳(99078) 星期三5-8节 [1-16] 学院专教C203\\n')")
+              "(3203, 2003, '99078', '俞泳', '李彦伯(14022),陈洁(22211),俞泳(99078) 星期三5-8节 [1-16] 学院专教C203\\n'),"
+              # 部分重叠排课：赵盈和李舒怡，共享 [6] 南310 但各有独自安排
+              "(3301, 3001, '07048', '赵盈', '赵盈(07048),李舒怡(21088) 星期三9-10节 [6] 南310\\n赵盈(07048) 星期三9-10节 [1 7-16] 南310\\n'),"
+              "(3302, 3001, '21088', '李舒怡', '李舒怡(21088) 星期三9-10节 [2-5] 南310\\n赵盈(07048),李舒怡(21088) 星期三9-10节 [6] 南310\\n')")
 
     # 专业
     c.execute("INSERT INTO major (id, code, grade, name) VALUES "
@@ -224,6 +229,35 @@ class TestCourseDetails:
         assert resp.status_code == 400
 
 
+class TestCourseDetails:
+    def test_batch_details(self, client, seed_data):
+        resp = client.post('/api/calendars/999/courses/details',
+                           json={'courseCodes': ['340012']})
+        assert resp.status_code == 200
+        assert '340012' in resp.json['data']
+
+    def test_batch_details_empty(self, client):
+        resp = client.post('/api/calendars/999/courses/details',
+                           json={'courseCodes': []})
+        assert resp.status_code == 400
+
+    def test_partial_overlap_dedup(self, client, seed_data):
+        """部分重叠排课：共享行只出现一次"""
+        resp = client.post('/api/calendars/999/courses/details',
+                           json={'courseCodes': ['511112']})
+        assert resp.status_code == 200
+        details = resp.json['data']['511112']
+        assert len(details) == 1  # 一个教学班
+        arr = details[0]['arrangementInfo']
+        assert len(arr) == 3, \
+            f"去重后应为 3 条（1条共享+2条独有），实际 {len(arr)} 条"
+        # 共享行 [6] 南310 只出现一次
+        texts = [a['arrangementText'] for a in arr]
+        count_shared = sum(1 for t in texts if '[6]' in t)
+        assert count_shared == 1, \
+            f"共享行 '[6] 南310' 应出现 1 次，实际 {count_shared} 次"
+
+
 class TestSearch:
     def test_search_by_name(self, client, seed_data):
         resp = client.post('/api/calendars/999/courses/search',
@@ -253,3 +287,40 @@ class TestSyncBatch:
         resp = client.post('/api/calendars/999/courses/batch',
                            content_type='application/json')
         assert resp.status_code == 400
+
+    def test_batch_shared_arrangement(self, client, seed_data):
+        """batch: 共同排课（3个老师完全相同）→ 去重后只有 1 条 arrangementInfo"""
+        resp = client.post('/api/calendars/999/courses/batch',
+                           json={'otherCourseCodes': ['020527']})
+        assert resp.status_code == 200
+        course_list = resp.json['data']['020527']
+        assert len(course_list) == 1  # 一个教学班
+        assert len(course_list[0]['teachers']) == 3  # 3 个老师
+        assert len(course_list[0]['arrangementInfo']) == 1, \
+            f"共同排课去重后应为 1 条，实际 {len(course_list[0]['arrangementInfo'])} 条"
+
+    def test_batch_split_arrangement(self, client, seed_data):
+        """batch: 分工排课（不同老师不同安排）→ 全部保留"""
+        resp = client.post('/api/calendars/999/courses/batch',
+                           json={'otherCourseCodes': ['100395']})
+        assert resp.status_code == 200
+        course_list = resp.json['data']['100395']
+        assert len(course_list) == 2  # 两个教学班
+        for detail in course_list:
+            assert len(detail['arrangementInfo']) == 4, \
+                f"分工排课每个班应为 4 条，实际 {len(detail['arrangementInfo'])} 条"
+
+    def test_batch_partial_overlap_dedup(self, client, seed_data):
+        """batch: 部分重叠排课 → 共享行只出现一次"""
+        resp = client.post('/api/calendars/999/courses/batch',
+                           json={'otherCourseCodes': ['511112']})
+        assert resp.status_code == 200
+        course_list = resp.json['data']['511112']
+        assert len(course_list) == 1  # 一个教学班
+        arr = course_list[0]['arrangementInfo']
+        assert len(arr) == 3, \
+            f"去重后应为 3 条（1条共享+2条独有），实际 {len(arr)} 条"
+        texts = [a['arrangementText'] for a in arr]
+        count_shared = sum(1 for t in texts if '[6]' in t)
+        assert count_shared == 1, \
+            f"共享行 '[6] 南310' 应出现 1 次，实际 {count_shared} 次"

--- a/backend/utils/bckndTools.py
+++ b/backend/utils/bckndTools.py
@@ -147,10 +147,41 @@ def splitEndline(text):
     输入： "关佶红(05222) 星期一3-4节 [1-17] 南129\n关佶红(05222) 星期三3-4节 [1-17单] 北301\n"
     输出： ["关佶红(05222) 星期一3-4节 [1-17] 南129", "关佶红(05222) 星期三3-4节 [1-17单] 北301"]
     '''
-    
+
     # print(text.split("\n")[:-1])
 
     return text.split("\n")[:-1]
+
+
+def parseArrangements(course, source_key='locations'):
+    '''
+    将课程字典中的 locations/arrangementInfo 字符串解析为结构化 arrangementInfo 数组。
+    原地修改，不返回值。
+    '''
+    text = course[source_key]
+    seen = set()
+    course['arrangementInfo'] = []
+    for location in splitEndline(text):
+        obj = arrangementTextToObj(location)
+        if obj['arrangementText'] not in seen:
+            # 这一步不能省略，因为很有可能一位老师包含多个排课时段子串，这些字符串拼接起来不同，但是可能存在重复的子串
+            course['arrangementInfo'].append(obj)
+            seen.add(obj['arrangementText'])
+    course['arrangementInfo'].sort(
+        key=lambda x: (x['occupyDay'], x['occupyTime'][0] if x['occupyTime'] else 0)
+    )
+    if source_key != 'arrangementInfo':
+        del course[source_key]
+
+
+def processArrangements(details, source_key='locations'):
+    '''
+    对一个课程详情列表批量解析 arrangementInfo，并按 code 排序。
+    原地修改，不返回值。
+    '''
+    for detail in details:
+        parseArrangements(detail, source_key)
+    details.sort(key=lambda x: x['code'])
 
 def optCourseQueryListGenerator(day, section, calendarId=0):
     '''

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       MYSQL_ROOT_PASSWORD: ${DB_PASSWORD:-}
       MYSQL_ROOT_HOST: "%"
       TZ: Asia/Shanghai
-    command: --default-time-zone=+08:00
+    command: --default-time-zone=+08:00 --slow-query-log=1 --long-query-time=1
     volumes:
       - mysql_data:/var/lib/mysql
       - ./crawler/meta_template.sql:/docker-entrypoint-initdb.d/01_meta.sql:ro


### PR DESCRIPTION
Closes #83 

主要的修改是：

1. 数据库容器启动慢查询日志；
2. 对 `/api/calendars/[id]/courses/search` 接口，优化查询速度，改为内部子查询先定位课号，随后在外层进行昂贵的 JSON；
3. 此外，对于使用共同序列化的接口，提取公共函数，并且发现了一个极端的去重失败情形，并添加测试。